### PR TITLE
Updates to accomodate latest dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <script type="text/javascript" src="assets/js/es5-shim.min.js"></script>
         <script type="text/javascript" src="assets/js/es5-sham.min.js"></script>
         <script type="text/javascript" src="assets/js/console-polyfill.js"></script>
-        <script src="http://fb.me/react-0.9.0.js"></script>
+        <script src="http://fb.me/react-0.11.2.js"></script>
         <script type="text/javascript" src="http://d3js.org/d3.v3.min.js"></script>
         <script type="text/javascript" src="assets/js/nv.d3.min.js"></script>
         <script src="out/goog/base.js" type="text/javascript"></script>

--- a/project.clj
+++ b/project.clj
@@ -3,18 +3,18 @@
   :url "http://example.com/FIXME"
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2173"] ;; 2199
-                 [org.clojure/core.async "0.1.278.0-76b25b-alpha"]
-                 [org.clojure/core.cache "0.6.3"]
-                 [om "0.5.3"]
-                 [sablono "0.2.15"]
-                 [com.taoensso/sente "0.9.0"]
-                 [http-kit "2.1.18"]
-                 [compojure "1.1.6"]
-                 [ring/ring-core "1.2.2"]
+                 [org.clojure/clojurescript "0.0-2356"] ;; 2199
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.clojure/core.cache "0.6.4"]
+                 [om "0.7.3"]
+                 [sablono "0.2.22"]
+                 [com.taoensso/sente "1.2.0"]
+                 [http-kit "2.1.19"]
+                 [compojure "1.2.0"]
+                 [ring/ring-core "1.3.1"]
                  [jetty/javax.servlet "5.1.12"]]
 
-  :plugins [[lein-cljsbuild "1.0.2"]] ;; 1.0.3
+  :plugins [[lein-cljsbuild "1.0.3"]] ;; 1.0.3
 
   :source-paths ["src/clj"]
 

--- a/src/clj/om_sente/server.clj
+++ b/src/clj/om_sente/server.clj
@@ -131,7 +131,7 @@
 
 ;; When the client pings us, send back the session state:
 
-(defmethod handle-event :chsk/ping
+(defmethod handle-event :chsk/ws-ping
   [_ req]
   (session-status req))
 


### PR DESCRIPTION
Thank you for putting this together Mr. Corfield.  Here is an update that I put together to get things working after I performed "lein ancients upgrade".   The only change that may not be correct is the :chsk/ws-ping diff in server.clj.  Everything seemed to work on the latest versions of Firefox, Chrome and Safari from OSX 10.9.5.
